### PR TITLE
Remove side channel hack of knowing number of metric expressions

### DIFF
--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -19,13 +19,12 @@ logger = logging.getLogger(__name__)
 
 class PinotCompiler(compiler.SQLCompiler):
     def visit_select(self, select, **kwargs):
-        # Pinot does not support orderby-limit for aggregating queries, replace that with
-        # top keyword. (The order by info is lost since the result is always ordered-desc by the group values)
-        has_metrics = getattr(select, '_num_metric_expressions', 0) > 0
         if select._offset_clause:
             raise exceptions.NotSupportedError('Offset clause is not supported in pinot')
         top = None
-        if has_metrics:
+        # Pinot does not support orderby-limit for aggregating queries, replace that with
+        # top keyword. (The order by info is lost since the result is always ordered-desc by the group values)
+        if select._group_by_clause is not None:
             logger.debug(f'Query {select} has metrics, so rewriting its order-by/limit clauses to just top')
             top = 100
             if select._limit_clause is not None:


### PR DESCRIPTION
The issue here is to distinguish b/w a query having metrics or not. 

For example, the query 'select count(1) from foo' has metrics, while the query 'select mult(bar, 2) from foo' does not. Pinot does not allow order-by clause on queries with metrics. It gives a null pointer exception if you try to cram an order-by for a metric-query.

Luckily Superset places an empty group-by clause in the SqlAlchemy query when placing any metrics (even without any group by columns). We use that hint to determine whether it is a query with or without metrics.